### PR TITLE
Add SCORM upload functionality

### DIFF
--- a/app/Livewire/Forms/ScormUploadForm.php
+++ b/app/Livewire/Forms/ScormUploadForm.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Livewire\Forms;
+
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+use ZipArchive;
+
+class ScormUploadForm extends Component
+{
+    use WithFileUploads;
+
+    public $scormZip;
+
+    protected $rules = [
+        'scormZip' => 'required|file|mimes:zip|max:10240', // 10MB Max
+    ];
+
+    public function upload()
+    {
+        $this->validate();
+
+        $path = $this->scormZip->store('scorm_uploads');
+
+        $zip = new ZipArchive;
+        if ($zip->open(storage_path('app/' . $path)) === TRUE) {
+            $extractPath = storage_path('app/scorm_packages/' . pathinfo($path, PATHINFO_FILENAME));
+            $zip->extractTo($extractPath);
+            $zip->close();
+
+            if ($this->isValidScormPackage($extractPath)) {
+                // Save the valid SCORM package to the server
+                Storage::move('app/' . $path, 'scorm_packages/' . pathinfo($path, PATHINFO_FILENAME));
+                session()->flash('message', 'SCORM package uploaded and validated successfully.');
+            } else {
+                Storage::delete($path);
+                session()->flash('error', 'Invalid SCORM package.');
+            }
+        } else {
+            session()->flash('error', 'Failed to unpack the SCORM zip.');
+        }
+    }
+
+    private function isValidScormPackage($path)
+    {
+        // Implement SCORM package validation logic here
+        // For example, check for the existence of imsmanifest.xml
+        return file_exists($path . '/imsmanifest.xml');
+    }
+
+    public function render()
+    {
+        return view('livewire.forms.scorm-upload-form');
+    }
+}

--- a/resources/views/livewire/pages/scorm/upload.blade.php
+++ b/resources/views/livewire/pages/scorm/upload.blade.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Livewire\Forms\ScormUploadForm;
+use Livewire\Volt\Component;
+
+new class extends Component
+{
+    public ScormUploadForm $form;
+
+    public function upload()
+    {
+        $this->validate();
+
+        $this->form->upload();
+    }
+}; ?>
+
+<div>
+    @if (session()->has('message'))
+        <div class="alert alert-success">
+            {{ session('message') }}
+        </div>
+    @endif
+
+    @if (session()->has('error'))
+        <div class="alert alert-danger">
+            {{ session('error') }}
+        </div>
+    @endif
+
+    <form wire:submit="upload">
+        <div>
+            <x-input-label for="scormZip" :value="__('SCORM Zip')" />
+            <x-text-input wire:model="form.scormZip" id="scormZip" class="block mt-1 w-full" type="file" name="scormZip" required />
+            <x-input-error :messages="$errors->get('form.scormZip')" class="mt-2" />
+        </div>
+
+        <div class="flex items-center justify-end mt-4">
+            <x-primary-button class="ms-3">
+                {{ __('Upload') }}
+            </x-primary-button>
+        </div>
+    </form>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,4 +12,9 @@ Route::view('profile', 'profile')
     ->middleware(['auth'])
     ->name('profile');
 
+Route::middleware('auth')->group(function () {
+    Route::get('upload-scorm', \App\Livewire\Forms\ScormUploadForm::class)
+        ->name('upload-scorm');
+});
+
 require __DIR__.'/auth.php';


### PR DESCRIPTION
Add functionality for signed-in users to upload, unpack, validate, and save SCORM zip files.

* Create a new Livewire component `ScormUploadForm` in `app/Livewire/Forms/ScormUploadForm.php` to handle SCORM zip upload, unpacking, and validation.
* Add properties for the uploaded file and validation rules in `ScormUploadForm`.
* Implement the `upload` method in `ScormUploadForm` to handle file upload, unpacking, and validation.
* Save the valid SCORM package to the server in `ScormUploadForm`.
* Add a new route in `routes/web.php` for the SCORM upload form, accessible via `/upload-scorm`.
* Create a new Blade view `resources/views/livewire/pages/scorm/upload.blade.php` for the SCORM upload form.
* Add a form to upload the SCORM zip file in the Blade view.
* Display validation errors and success messages in the Blade view.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/prindom/archimedes/pull/2?shareId=03b179e2-8065-47e2-b7b8-3245e7400699).